### PR TITLE
Small change to fix modern pip3 packaging change breakage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [0.2.1] (2024-05-26)
+
+* Small change to fix modern pip3 packaging change breakage
+
 ## [0.2.0][1] (2024-02-18)
 
 * Updated musashi code base to 2158f7081001f89145283d291ee501321e8dc26d

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,9 @@ from distutils import ccompiler
 from distutils.dir_util import remove_tree
 from distutils import log
 
+NAME = "machine68k"
+VERSION = "0.2.1"
+
 # has cython?
 try:
     from Cython.Build import cythonize
@@ -213,6 +216,8 @@ else:
     sourcefiles.append(ext_file)
 
 setup(
+    name=NAME,
+    version=VERSION,
     cmdclass=cmdclass,
     command_options=command_options,
     ext_modules=extensions,


### PR DESCRIPTION
Sometimes, metadata resolution seems to fail via metadata, resulting in a project name of "unknown", breaking dependencies all kind of ways (in pip 22.0.2 and others), even when installing from the git repository directly.

While users could be asked to upgrade to a newer pip version, this fix addresses the issue without introducing additional problems.