### PR TITLE
Fix opcode table over-read crash on Windows

### DIFF
--- a/src/musashi/m68k_in.c
+++ b/src/musashi/m68k_in.c
@@ -182,7 +182,7 @@ void m68ki_build_opcode_table(void)
 	}
 
 	ostruct = m68k_opcode_handler_table;
-	while(ostruct->mask != 0xff00)
+	while(ostruct->mask != 0xff00 && ostruct->mask != 0)
 	{
 		for(i = 0;i < 0x10000;i++)
 		{


### PR DESCRIPTION
## Problem

`machine68k.CPU()` crashes with `ACCESS_VIOLATION` on Windows. The segfault occurs during `m68k_init()` → `m68ki_build_opcode_table()`, before any user code runs.

## Root cause

The opcode handler table is terminated by a zero sentinel `{0, 0, 0, {0,0,0,0,0}}`. The first `while` loop in `m68ki_build_opcode_table()` scans forward looking for `mask == 0xff00` as a phase transition:

```c
while(ostruct->mask != 0xff00)
```

However, `m68kmake` never generates entries with mask `0xff00`. The loop processes all ~1967 valid entries, reaches the zero terminator, evaluates `0 != 0xff00` as true, and continues reading past the end of the array.

On Linux/macOS this happens to work — the over-read lands in zero-filled BSS, and the subsequent `==` loops (`mask == 0xf1f8`, `mask == 0xfff0`, etc.) all exit immediately on mask=0, so the function completes despite the undefined behavior. On Windows, the `.rdata` section layout places the const array near a page boundary, and the over-read crosses into unmapped memory.

The subsequent loops are safe because they use `==` checks, which naturally terminate when they encounter a different or zero mask value. Only the first loop, which scans forward with `!=`, has this problem.

## Fix

Add a zero-terminator guard to the first loop so it stops at the end of the table:

```c
while(ostruct->mask != 0xff00 && ostruct->mask != 0)
```

## Verification

- `CPU(1)` no longer segfaults on Windows (tested Python 3.13 and 3.14)
- `Machine(1, 1024)` works correctly
- 41 tests pass, 34 skipped (pre-existing `[remote]`/`[greenlet]` skip conditions)