### PR TITLE
Fix JMP/CAS opcode collision caused by MSVC miscompilation

### DIFF
--- a/src/musashi/m68kmake.c
+++ b/src/musashi/m68kmake.c
@@ -1141,12 +1141,19 @@ void populate_table(void)
 		}
 
 		/* generate mask and match from bitpattern */
-		op->op_mask = 0;
-		op->op_match = 0;
-		for(i=0;i<16;i++)
+		/* Use intermediate unsigned int variables to work around an MSVC
+		 * /O2 optimization bug where |= on unsigned short struct members
+		 * through a pointer drops bit 14 (0x4000). */
 		{
-			op->op_mask |= (bitpattern[i] != '.') << (15-i);
-			op->op_match |= (bitpattern[i] == '1') << (15-i);
+			unsigned int mask = 0;
+			unsigned int match = 0;
+			for(i=0;i<16;i++)
+			{
+				mask |= (bitpattern[i] != '.') << (15-i);
+				match |= (bitpattern[i] == '1') << (15-i);
+			}
+			op->op_mask = (unsigned short)mask;
+			op->op_match = (unsigned short)match;
 		}
 	}
 	/* Terminate the list */


### PR DESCRIPTION
## Problem

Every non-PC-relative `JMP` instruction on 68020+ silently executes as `CAS` (Compare and Swap), producing bogus memory accesses. For example, `JMP $2318.L` reads memory at `0x23180000` instead of jumping to `0x2318`.

## Root cause

`m68kmake` generates opcode mask and match values by accumulating bits with `|=` on `unsigned short` struct members through a pointer:

```c
op->op_mask |= (bitpattern[i] != '.') << (15-i);
op->op_match |= (bitpattern[i] == '1') << (15-i);
```

MSVC's `/O2` optimizer miscompiles this pattern, silently dropping bit 14 (`0x4000`) from the stored values. JMP (`0x4eXX`) and CAS (`0x0eXX`) differ only in bit 14, so with bit 14 lost they produce identical mask/match entries in the generated opcode table. Since CAS appears after JMP in the sorted table, its handler overwrites JMP's for all shared opcode slots.

On GCC/Clang the `|=` compiles correctly and the collision doesn't occur. This is why the bug only manifests on Windows (MSVC).

### All affected addressing modes

| Mode | JMP opcode | Should match | Actually matches (MSVC) |
|------|-----------|-------------|------------------------|
| `jmp (An)` | `0x4ed0` | `0x4ed0` | `0x0ed0` (= CAS) |
| `jmp (d16,An)` | `0x4ee8` | `0x4ee8` | `0x0ee8` (= CAS) |
| `jmp (d8,An,Xn)` | `0x4ef0` | `0x4ef0` | `0x0ef0` (= CAS) |
| `jmp (xxx).W` | `0x4ef8` | `0x4ef8` | `0x0ef8` (= CAS) |
| `jmp (xxx).L` | `0x4ef9` | `0x4ef9` | `0x0ef9` (= CAS) |

JSR, BRA, and PC-relative JMP modes are unaffected.

## Fix

Accumulate mask and match values in `unsigned int` locals before assigning to the `unsigned short` struct members. This avoids the problematic `|=` through a pointer to a narrow type, which is where MSVC's optimizer generates incorrect code.

## Verification

- `amifuse ls` no longer produces `invalid memory access: addr=23180000` — the handler starts, runs, and shuts down (previously every JMP in the handler binary was misexecuted)
- JMP instruction dispatches to the correct handler (verified by comparing generated opcode table entries before and after)
- 68000 mode is unaffected (CAS is 68020+ only)